### PR TITLE
With --partial-certificate, print partial model in DIMACS format

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -298,7 +298,7 @@ int main(int argc, char** argv)
     lbool result = solver->solve();
 
     if (result != l_Undef && vm["partial-certificate"].as<bool>() && !learning_engine.reducedLast().empty()) {
-      cout << learning_engine.reducedLast() << "\n";
+      cout << "v " << learning_engine.reducedLast() << "0\n";
     }
 
     if (vm["print-stats"].as<bool>()) {


### PR DESCRIPTION
This is the behaviour chosen for most QBF solvers:
- caqe --partial-assignments
- depqbf --qdo --no-dynamic-nenofex
- quantor (no option needed)

The partial assignment has the form:

    v -1 2 4 -5 -6 0

instead of 

    -1 2 4 -5 -6