### PR TITLE
Fix pthread error on linux/Boost 1.65.1/glibc 2.2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,13 @@ set(Boost_USE_STATIC_LIBS OFF)
 
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.60.0 COMPONENTS program_options thread log system REQUIRED)
+
 if (Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
 else(Boost_FOUND)
   message(FATAL_ERROR "Qute requires Boost version 1.60 or above.")
 endif (Boost_FOUND)
+
+find_package(Threads REQUIRED)
 
 add_subdirectory("src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(Boost_USE_STATIC_LIBS OFF)
 # set(Boost_USE_MULTITHREADED ON)
 
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.60.0 COMPONENTS program_options thread log system)
+find_package(Boost 1.60.0 COMPONENTS program_options thread log system REQUIRED)
 if (Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
 else(Boost_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,4 +3,4 @@ file(GLOB SOURCES *.cc)
 add_executable(qute ${SOURCES})
 set_target_properties(qute PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-target_link_libraries(qute ${Boost_LIBRARIES})
+target_link_libraries(qute ${Boost_LIBRARIES} Threads::Threads)


### PR DESCRIPTION
Here is another fix :)

I was getting the error on travis-ci (glibc 2.2.5, boost 1.65.1); I could reproduce it on multiple linux boxes.

```
CMakeFiles/qute.dir/watched_literal_propagator.cc.o  -o ../qute
-lboost_program_options-mt -lboost_thread-mt -lboost_log-mt
-lboost_system-mt -lboost_chrono-mt -lboost_date_time-mt
-lboost_atomic-mt -lboost_log_setup-mt -lboost_filesystem-mt
-lboost_regex-mt
/home/linuxbrew/.linuxbrew/bin/ld: CMakeFiles/qute.dir/main.cc.o:
undefined reference to symbol 'pthread_rwlock_wrlock@@GLIBC_2.2.5'
//home/linuxbrew/.linuxbrew/lib/libpthread.so.0: error adding symbols:
//DSO missing from command line
collect2: error: ld returned 1 exit status
```

---

Also add REQUIRED in order to have explanations when Boost is not found (#1)
