### PR TITLE
Fix ubuntu 20 build because of underlying type mismatch

### DIFF
--- a/src/dependency_manager_rrs.hh
+++ b/src/dependency_manager_rrs.hh
@@ -16,7 +16,7 @@ using std::string;
 namespace Qute {
 
 class QCDCL_solver;
-enum ConstraintType;
+enum ConstraintType: unsigned short;
 
 class DependencyManagerRRS: public DependencyManagerWatched {
 


### PR DESCRIPTION
Under ubuntu 20.04 and compilation as described in the readme I ran into: 
```
In file included from /home/valentin/code/sat/qute/src/dependency_manager_rrs.cc:1:
/home/valentin/code/sat/qute/src/dependency_manager_rrs.hh:19:6: error: enumeration previously declared with fixed underlying type
enum ConstraintType;
     ^
/home/valentin/code/sat/qute/src/solver_types.hh:43:6: note: previous declaration is here
enum ConstraintType: unsigned short { clauses = 0, terms = 1 };
     ^
1 error generated.
``` 

I had to make the type of the enum explicit and the compilation worked. 
https://stackoverflow.com/questions/42766839/c11-enum-forward-causes-underlying-type-mismatch#42768812